### PR TITLE
Propose: per-fleet adapter registry (RFC #37)

### DIFF
--- a/openspec/changes/2026-05-15-per-fleet-adapter-registry/.openspec.yaml
+++ b/openspec/changes/2026-05-15-per-fleet-adapter-registry/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-15

--- a/openspec/changes/2026-05-15-per-fleet-adapter-registry/design.md
+++ b/openspec/changes/2026-05-15-per-fleet-adapter-registry/design.md
@@ -1,0 +1,95 @@
+## Context
+
+The Enclz core program currently enumerates every supported protocol as a dedicated `execute_*` instruction. As of v0.5.x the core ships three: `execute_transfer`, `execute_swap` (Jupiter), and `execute_lending_op` (Kamino/Save). Each new protocol the team wants to support is a fresh instruction with bespoke CPI plumbing, account validation, and tests.
+
+Three pressures push against this model:
+
+1. **Program-size and audit-surface growth.** BPF binaries have a ceiling and audits scale with surface area. A backlog of integrations (Drift, Phoenix, Marginfi, Meteora, Orca, NFT marketplaces, perps, oracles, vaults, …) means the core trends toward a monolith. Immutability — the only credible commitment that "Enclz will never push a malicious upgrade" — gets pushed further out the longer this continues.
+2. **Trust model coherence.** Enclz's pitch is non-custodial: the group owner is the trust root, the chain is the enforcer, and Enclz the operator can be compromised without funds being drainable beyond policy ceilings. A globally-governed adapter registry (multisig, DAO, etc.) re-introduces Enclz as a trust dependency for protocol approval. A per-fleet, owner-controlled registry keeps the trust root where it already is.
+3. **Competitive context.** QuantuLabs shipped `Agent-Vault` to devnet on 2026-05-14 with an `execute_cpi_checked` instruction that allows arbitrary CPI under structural post-checks (no Token/ATA/loader targets, custody verification, no SPL multisig satisfiable by the wallet PDA) — but **no per-target allowlist**. Enclz adds the pre-check gate on top of the same post-checks, which is strictly more conservative and sharpens the "policy-first" positioning.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Core program shrinks to: provisioning, whitelist, `execute_transfer`, `execute_via_adapter`, `add_adapter` / `remove_adapter`
+- Group owner permissionlessly manages the adapter registry for their fleet
+- The chain validates: adapter is on the owner's approved list (pre-check), amount caps respected, output ATAs are PDA-owned (post-check)
+- `execute_swap` and `execute_lending_op` move out of the core to first-party adapter programs (Apache-2.0, out-of-tree)
+- Owner authority surface unchanged: same wallet that signs `initialize_group` / `add_to_whitelist` / `add_agent` signs `add_adapter` / `remove_adapter`
+- Per-adapter constraints (opaque `Vec<u8>` parsed by the adapter) let the owner narrow allowed inputs without the core understanding protocol semantics
+
+**Non-Goals:**
+- Global adapter approval / governance / multisig — explicitly off the table
+- Cross-adapter composability (adapter calling adapter) — out of scope for v1.0; each `execute_via_adapter` is one hop
+- Canonical-latest version pointers — exact-pin only (see Decision 1)
+- Migration-window backwards compatibility with v0.x instructions — v1.0 is a clean break, served by a fresh program ID; v0.x deployment is deprecated, not patched
+
+## Decisions
+
+### Decision 1: Exact-pin adapter program IDs
+
+The `GroupAdapterRegistry` stores literal `Pubkey` values for each approved adapter. There is no "canonical latest" pointer abstraction. Upgrading to a new adapter version means the owner calls `remove_adapter(old_id)` + `add_adapter(new_id, …)`.
+
+Rationale:
+- Trivially safe: an attacker controlling a "latest pointer" would gain backdoor authority to redirect every fleet pointing at it
+- No extra state, no extra trust surface — keeps the v1.0 scope tight
+- Owner-friendly upgrade flow is a webapp concern (notify owner of new adapter versions; one-click prompt to call remove+add)
+
+### Decision 2: Fail-loud on removed adapters mid-flight
+
+`execute_via_adapter` checks adapter membership at execution time. If the owner removed the adapter between the agent reserving an idempotency key and the operator executing the chain call, the on-chain instruction fails with `AdapterNotApproved` (new 6000-band variant).
+
+Rationale:
+- Trivial to implement — one check at execute-time, no snapshot logic, no per-intent state
+- Owners get real-time control: pulling the adapter is immediately effective, no zombie in-flight calls
+- Backend surfaces the error as a typed API response via `parseAnchorError` in `shared/anchor-errors.js`
+
+### Decision 3: First-party adapters only for v1.0, primitive is permissionless
+
+We ship `enclz-jupiter-adapter`, `enclz-kamino-adapter`, and `enclz-save-adapter` as first-party Apache-2.0 programs in v1.0. A reference `adapter-template` is also shipped (public repo) so the pattern is documented. The "How to write an adapter" guide and external-author support are deferred to v1.1 once the pattern has stabilized through real shipping.
+
+The on-chain primitive itself is permissionless from day one — any owner can add any deployed program to their registry. We don't gate authorship, we just don't officially support external adapters until v1.1.
+
+Rationale:
+- Pre-release: don't promise a stable ABI we haven't proven yet
+- First-party adapters cover the entire v0.x feature surface; no functional regression for migrating users
+- Permissionless primitive means power users / sophisticated partners can ship their own adapters without waiting on us
+
+### Decision 4: Empty default registry, curated off-chain catalog
+
+A freshly-initialized group has no adapters. Only `execute_transfer` works until the owner explicitly calls `add_adapter`. The webapp ships a "Recommended Adapters" panel that surfaces the first-party adapter program IDs and lets the owner add them with one click. This is purely off-chain UX.
+
+Rationale:
+- "No silent defaults" matches the non-custodial principle — the owner sees and approves every program their fleet can call
+- Curation lives off-chain in the webapp, not on chain — keeps the chain primitive purely permissionless
+
+### Decision 5: New capability split — `adapter-management` and `adapter-execution`
+
+Per existing capability naming (`whitelist-management` vs `transfer-execution`), the management surface and the execution surface are separate capabilities. `adapter-management` covers `add_adapter` / `remove_adapter` + the registry account layout requirements specific to mutation. `adapter-execution` covers `execute_via_adapter`. The shared registry account is documented in `program-state` (the canonical location for cross-capability data structures).
+
+### Decision 6: Per-adapter `constraints: Vec<u8>` is opaque to the core
+
+The adapter program is responsible for parsing `constraints` and validating the inbound call against it. The core stores the bytes verbatim and passes them through on every `execute_via_adapter` call. Each adapter defines its own `constraints` schema.
+
+Rationale:
+- Keeps the core protocol-agnostic — no new schema variants per adapter family
+- Adapters encode their own whitelist semantics (e.g., the Kamino adapter parses "allowed-market list" out of its `constraints`; the perps adapter parses "max leverage"; etc.)
+- Empty `constraints: Vec<u8>` is the "no per-adapter restriction" default
+
+### Decision 7: New program ID for v1.0, no in-place upgrade from v0.x
+
+v1.0 ships under a freshly-generated program keypair. v0.x continues to run for the migration window but is marked deprecated. Owners running the "Migrate Group" webapp flow re-initialize their group on the new program ID and add the recommended adapters via `add_adapter` calls signed from their wallet.
+
+Rationale:
+- Avoids the IDL-rotation pain of trying to upgrade a deployed program that's removing instructions
+- Lets v1.0 freeze its upgrade authority shortly after audit (per the long-term immutability goal)
+- The non-zero migration cost is acceptable pre-release
+
+## Risks / Trade-offs
+
+- **Risk: A malicious adapter program drains funds up to policy caps.** The chain validates the adapter is on the owner's approved list and that output ATAs are PDA-owned, but the adapter itself can call into arbitrary downstream programs. If the owner adds an adapter that proxies to a malicious target, the agent's daily-cap worth of funds is at risk. **Mitigation:** the same risk exists today for the whitelist (a malicious whitelist target could be an attacker-controlled wallet). Owners are responsible for due diligence on adapter program IDs they approve. The webapp curates a "Recommended" catalog. We add an "adapter authority status" indicator (frozen vs. upgradeable) to the webapp to help owners assess.
+- **Risk: Adapter program upgradeable-authority compromise.** If a first-party adapter is still upgradeable and we lose key control, every fleet that registered that adapter ID is exposed. **Mitigation:** each adapter program freezes its upgrade authority shortly after release + audit, following the same long-term immutability path as the core.
+- **Risk: Migration friction.** Owners who don't migrate lose swap/lending until they opt in. **Mitigation:** "Migrate Group" wizard in the webapp prompts one-tx adapter additions; in-product banner messaging; clear changelog. Pre-release, migration friction is acceptable.
+- **Risk: Adapter discoverability is now an off-chain UX problem.** **Mitigation:** webapp panel with curated catalog; docs section explaining the registry; ecosystem partners can self-register their canonical adapter program IDs over time.
+- **Trade-off: v0.x backend code (`server/lib/intents.js`) must be rewritten.** `executeSwap` / `executeLendingOp` callers either (a) remap to `executeViaAdapter` + an adapter program ID lookup, or (b) get deprecated and removed from the API. Decided at implementation time depending on how many client integrations exist.
+- **Trade-off: SDK + MCP surface widens.** The MCP server gains an `executeAdapter` tool (or we keep `swap` / `deposit` / `withdraw` as named wrappers, each mapped to a canonical adapter program ID for that protocol). Trade is between (a) wider but lower-level tool surface, and (b) named/curated tools that hide the adapter abstraction. Decided alongside the backend deprecation path.

--- a/openspec/changes/2026-05-15-per-fleet-adapter-registry/proposal.md
+++ b/openspec/changes/2026-05-15-per-fleet-adapter-registry/proposal.md
@@ -1,0 +1,50 @@
+## Why
+
+Every new DeFi protocol Enclz wants to support today requires a dedicated `execute_*` instruction added to the core program (`execute_swap`, `execute_lending_op`, future `execute_perp_*`, `execute_nft_*`, etc.). This drives two problems:
+
+1. **Core program grows monotonically.** Each protocol adds binary size, audit surface, and review burden. Long-term immutability of the core — the strongest possible security claim for the program — becomes harder to commit to with every protocol added.
+2. **Trust shape conflicts with non-custodiality.** Either the core enumerates every protocol (slow, unbounded growth) or a generic `execute_arbitrary_cpi` is introduced (rejected on 2026-05-12 — see `project_enclz_no_generic_wallet_abstraction.md` memory). A globally-governed adapter registry would solve breadth but re-introduce trust in Enclz governance, defeating the non-custodial property.
+
+Per-fleet, owner-controlled adapter registry resolves both: the core stays minimal, and protocol coverage scales through independently-deployed adapter programs whose program IDs are registered on a per-group basis by the group owner. The owner remains the trust root; the chain enforces the pre-check that any CPI target must be in the owner's approved list. Strictly more conservative than QuantuLabs' `Agent-Vault::execute_cpi_checked` (which has post-checks only).
+
+## What Changes
+
+- **NEW capability `adapter-management`:** introduces `GroupAdapterRegistry` PDA + `add_adapter` and `remove_adapter` instructions, owner-authority
+- **NEW capability `adapter-execution`:** introduces `execute_via_adapter` instruction, operator-authority, validates adapter membership + amount caps + custody, CPIs to the adapter with agent-PDA signer seeds
+- **BREAKING:** Remove `execute_swap` from core program (`programs/enclz/src/instructions/execute_swap.rs` deleted; entire `swap-execution` capability removed). Swap functionality moves to a first-party `enclz-jupiter-adapter` program shipped in a separate repository.
+- **BREAKING:** Remove `execute_lending_op` from core program (`programs/enclz/src/instructions/execute_lending_op.rs` deleted; entire `lending-execution` capability removed). Lending functionality moves to first-party adapter programs (`enclz-kamino-adapter`, `enclz-save-adapter`, …) shipped in separate repositories.
+- **BREAKING (default state):** A freshly-initialized group has an empty `GroupAdapterRegistry`. Until the owner calls `add_adapter`, only `execute_transfer` is available. Recommended adapters are surfaced as a curated catalog in the webapp orchestrator UI; the on-chain primitive itself is permissionless.
+- Add `AdapterNotApproved` error variant to `ErrorCode` (next free 6000-band discriminant)
+
+## Capabilities
+
+### New Capabilities
+
+- `adapter-management` — `GroupAdapterRegistry` PDA, `add_adapter`, `remove_adapter`
+- `adapter-execution` — `execute_via_adapter` (the generic dispatch instruction)
+
+### Modified Capabilities
+
+- `program-state` — adds `GroupAdapterRegistry` account layout
+
+### Removed Capabilities
+
+- `swap-execution` — entire capability removed; replaced by adapter programs out-of-tree
+- `lending-execution` — entire capability removed; replaced by adapter programs out-of-tree
+
+## Impact
+
+- **Program:** `programs/enclz/src/state/` (new `adapter_registry.rs`), `programs/enclz/src/instructions/` (delete `execute_swap.rs`, `execute_lending_op.rs`; add `add_adapter.rs`, `remove_adapter.rs`, `execute_via_adapter.rs`), `programs/enclz/src/lib.rs` (instruction registration changes), `programs/enclz/src/errors.rs` (add `AdapterNotApproved`)
+- **Tests:** delete `programs/enclz/tests/execute_swap.rs`, `programs/enclz/tests/execute_lending_op.rs`; add `tests/adapter_management.rs`, `tests/execute_via_adapter.rs`; update `tests/common/mod.rs` helpers
+- **Integration tests:** delete `tests/execute_swap.spec.ts`, `tests/execute_lending_op.spec.ts`; add `tests/adapter_management.spec.ts`, `tests/execute_via_adapter.spec.ts`; update `tests/smoke.ts`
+- **SDK:** new `addAdapter`, `removeAdapter`, `executeViaAdapter` helpers in `@enclz/sdk`; `swap` / `deposit` / `withdraw` removed from the SDK (downstream callers move to `executeViaAdapter` against the appropriate adapter program ID)
+- **Backend (webapp):** `server/lib/intents.js` loses `executeSwap` / `executeLendingOp`; gains `executeViaAdapter` that resolves adapter program IDs from the on-chain registry. The `/api/v1/swap`, `/api/v1/deposit`, `/api/v1/withdraw` routes either (a) are deprecated and removed, or (b) become thin wrappers that look up a canonical adapter program ID for the labeled protocol and call `executeViaAdapter`. Final shape decided in implementation.
+- **MCP server (`@enclz/mcp`):** the `swap`, `deposit`, `withdraw` tools either follow the backend's deprecation path or collapse into a single `executeAdapter` tool. Decided alongside backend.
+- **Docs:** `docs/SPECIFICATION.md` (`enclz/.github` submodule) needs an updated architecture section. `enclz/docs` site needs a new "Adapters" section covering the registry concept, the curated catalog, and how to register an adapter from the orchestrator UI. Per the user's standing rule, public docs are not updated in this change without explicit request.
+- **OpenSpec:** new `program-state/spec.md` requirement; new top-level `openspec/specs/adapter-management/spec.md`, `openspec/specs/adapter-execution/spec.md` files materialized on archive; top-level `openspec/specs/swap-execution/` and `openspec/specs/lending-execution/` directories removed on archive.
+- **First-party adapter repositories** (new, out-of-tree, Apache-2.0):
+  - `enclz/enclz-jupiter-adapter`
+  - `enclz/enclz-kamino-adapter`
+  - `enclz/enclz-save-adapter`
+  - `enclz/adapter-template` (reference template — public so external authors can mirror the pattern post-v1.0)
+- **Devnet rotation:** v1.0 ships under a new program ID. Existing v0.x groups remain on the deprecated program until owners run the "Migrate Group" flow described in `design.md`.

--- a/openspec/changes/2026-05-15-per-fleet-adapter-registry/specs/adapter-execution/spec.md
+++ b/openspec/changes/2026-05-15-per-fleet-adapter-registry/specs/adapter-execution/spec.md
@@ -1,0 +1,66 @@
+## ADDED Requirements
+
+### Requirement: execute_via_adapter instruction signature and account constraints
+
+The program SHALL expose `execute_via_adapter(adapter_id: Pubkey, call_data: Vec<u8>, amount: u64, expected_nonce: u64, agent_index: u8)` callable only by the `backend_operator` recorded on the agent's `GroupConfig`. The instruction validates the adapter is owner-approved, applies the same spend-limit + frequency policy checks as `execute_transfer`, and CPIs into the adapter program with the agent_wallet PDA's signer seeds.
+
+Required accounts: `backend_operator` (signer), `group_config`, `agent_wallet` (writable), `adapter_registry`, `adapter_program` (unchecked program account whose `key()` must equal `adapter_id` and must match an `Active` entry in `adapter_registry.entries`), plus `..remaining_accounts` forwarded to the adapter. The instruction enforces that every writable token account in `remaining_accounts` whose owner is the agent_wallet PDA is being mutated by the adapter only in ways consistent with the agent's custody (post-CPI ownership check).
+
+The instruction SHALL:
+- Reject if the signer is not `group_config.backend_operator` with `Unauthorized`
+- Reject if `adapter_id` is not present in `adapter_registry.entries` with `status == Active` (`AdapterNotApproved`)
+- Reject if `adapter_program.key() != adapter_id` with `AdapterNotApproved`
+- Reject if `adapter_id` is the SPL Token program, Associated Token program, or any BPF loader program ID with `AdapterNotApproved` (defense-in-depth)
+- Apply the agent's `per_tx_limit`, `daily_limit`, and `hourly_tx_cap` policy checks against `amount`
+- Increment `agent_wallet.spent_today` and the frequency counter on success
+- Validate `expected_nonce` matches `agent_wallet.nonce`; advance `nonce += 1` on success (replay protection identical to `execute_transfer`)
+- Invoke the adapter via `invoke_signed` passing `call_data` and the entry's stored `constraints: Vec<u8>` as adapter input, with the agent_wallet PDA seeds as signer
+- After the CPI returns, verify that every writable account in `remaining_accounts` whose `owner == agent_wallet PDA` is still owned by the agent_wallet PDA (custody post-check)
+
+#### Scenario: Non-operator signer rejected
+- **WHEN** any signer other than `GroupConfig.backend_operator` invokes `execute_via_adapter`
+- **THEN** the call fails with `Unauthorized`
+
+#### Scenario: Unregistered adapter rejected
+- **WHEN** `adapter_id` does not appear in `adapter_registry.entries`
+- **THEN** the call fails with `AdapterNotApproved` before any CPI
+
+#### Scenario: Paused adapter rejected
+- **WHEN** `adapter_id` appears in `adapter_registry.entries` but its `status == Paused`
+- **THEN** the call fails with `AdapterNotApproved`
+
+#### Scenario: adapter_program account mismatched with adapter_id rejected
+- **WHEN** the passed `adapter_program.key()` differs from `adapter_id`
+- **THEN** the call fails with `AdapterNotApproved`
+
+#### Scenario: Forbidden CPI target rejected
+- **WHEN** `adapter_id` equals the SPL Token program ID, the Associated Token program ID, or any BPF loader program ID
+- **THEN** the call fails with `AdapterNotApproved`
+
+#### Scenario: Per-tx limit enforced
+- **WHEN** `amount > agent_wallet.per_tx_limit`
+- **THEN** the call fails with `PerTxLimitExceeded` before any CPI
+
+#### Scenario: Daily limit enforced
+- **WHEN** `agent_wallet.spent_today + amount > agent_wallet.daily_limit`
+- **THEN** the call fails with `DailyLimitExceeded` before any CPI
+
+#### Scenario: Frequency cap enforced
+- **WHEN** the hourly transaction count would exceed `agent_wallet.hourly_tx_cap`
+- **THEN** the call fails with `FrequencyCapExceeded` before any CPI
+
+#### Scenario: Nonce mismatch rejected
+- **WHEN** `expected_nonce != agent_wallet.nonce`
+- **THEN** the call fails with `NonceMismatch`
+
+#### Scenario: Custody post-check on writable PDA-owned token accounts
+- **WHEN** the adapter's CPI changes the owner of a writable token account that was previously owned by the agent_wallet PDA
+- **THEN** the transaction reverts after the CPI returns with `CustodyViolation`
+
+#### Scenario: constraints passed to adapter verbatim
+- **WHEN** the registry entry for `adapter_id` has `constraints: Vec<u8>` of arbitrary length
+- **THEN** those exact bytes are forwarded to the adapter's entry-point as the constraints input
+
+#### Scenario: Nonce advances on success
+- **WHEN** `execute_via_adapter` completes successfully
+- **THEN** `agent_wallet.nonce` is incremented by exactly 1

--- a/openspec/changes/2026-05-15-per-fleet-adapter-registry/specs/adapter-management/spec.md
+++ b/openspec/changes/2026-05-15-per-fleet-adapter-registry/specs/adapter-management/spec.md
@@ -1,0 +1,65 @@
+## ADDED Requirements
+
+### Requirement: add_adapter instruction signature and account constraints
+
+The program SHALL expose `add_adapter(program_id: Pubkey, label: [u8; 32], constraints: Vec<u8>)` callable only by the `owner` recorded on the agent's `GroupConfig`. The instruction appends an `AdapterEntry` to the `GroupAdapterRegistry` for the calling group.
+
+Required accounts: `owner_signer` (signer, address-bound to `group_config.owner`), `group_config`, `adapter_registry` (writable, `init_if_needed` from seeds `["adapter_registry", group_config.key()]`), `system_program`.
+
+The instruction SHALL:
+- Reject if `entries.len() >= 32` with `AdapterRegistryFull`
+- Reject if an entry with the same `program_id` already exists with `Active` status, with `AdapterAlreadyRegistered`
+- Allow re-adding a `Paused` entry — promote it to `Active` and overwrite `label`, `constraints`, `added_at`
+- Set `status = Active` on insertion
+- Set `added_at` to the runtime clock unix timestamp at insertion time
+
+#### Scenario: Non-owner signer rejected
+- **WHEN** any signer other than `GroupConfig.owner` invokes `add_adapter`
+- **THEN** the call fails with `Unauthorized`
+
+#### Scenario: First call materializes the registry PDA
+- **WHEN** `add_adapter` is called against a group that has never had an adapter
+- **THEN** the `GroupAdapterRegistry` PDA is created, owner pays rent, and `entries` contains the one new entry
+
+#### Scenario: Duplicate Active program_id rejected
+- **WHEN** an active entry with the same `program_id` is already in the registry
+- **THEN** the call fails with `AdapterAlreadyRegistered`
+
+#### Scenario: Re-adding a Paused entry promotes it back to Active
+- **WHEN** an entry with the given `program_id` exists with `status == Paused` and `add_adapter` is called for the same `program_id`
+- **THEN** the existing entry is updated in place — `status` becomes `Active`, `label` and `constraints` are overwritten, `added_at` is refreshed
+
+#### Scenario: Over-cap insertion rejected
+- **WHEN** the registry already holds 32 entries (all Active or mixed) and `add_adapter` is called
+- **THEN** the call fails with `AdapterRegistryFull`
+
+#### Scenario: Constraints are stored verbatim
+- **WHEN** `add_adapter` is called with any well-formed `Vec<u8>` for `constraints`
+- **THEN** the registry entry stores those exact bytes for retrieval on subsequent `execute_via_adapter` calls
+
+### Requirement: remove_adapter instruction signature and account constraints
+
+The program SHALL expose `remove_adapter(program_id: Pubkey)` callable only by the `owner` recorded on the agent's `GroupConfig`. The instruction removes the matching `AdapterEntry` from the `GroupAdapterRegistry`.
+
+Required accounts: `owner_signer` (signer, address-bound to `group_config.owner`), `group_config`, `adapter_registry` (writable), `system_program`.
+
+The instruction SHALL:
+- Locate the entry by exact `program_id` match
+- Delete the entry (compact `entries` in place) if found
+- Succeed silently if no matching entry is present (idempotent removal)
+
+#### Scenario: Non-owner signer rejected
+- **WHEN** any signer other than `GroupConfig.owner` invokes `remove_adapter`
+- **THEN** the call fails with `Unauthorized`
+
+#### Scenario: Existing entry removed
+- **WHEN** `remove_adapter` is called against a `program_id` present in the registry
+- **THEN** the entry is removed; `entries.len()` decreases by 1
+
+#### Scenario: Missing entry is a no-op
+- **WHEN** `remove_adapter` is called against a `program_id` not in the registry
+- **THEN** the instruction succeeds with no state change (idempotent)
+
+#### Scenario: Registry PDA persists after last entry removed
+- **WHEN** the last entry is removed via `remove_adapter`
+- **THEN** the `GroupAdapterRegistry` PDA remains rent-paid with `entries.len() == 0`; the owner can `add_adapter` again without re-initializing

--- a/openspec/changes/2026-05-15-per-fleet-adapter-registry/specs/lending-execution/spec.md
+++ b/openspec/changes/2026-05-15-per-fleet-adapter-registry/specs/lending-execution/spec.md
@@ -1,0 +1,19 @@
+## REMOVED Requirements
+
+### Requirement: execute_lending_op instruction signature and account constraints
+
+The `execute_lending_op` instruction is removed from the core program. Lending functionality moves to first-party adapter programs — `enclz-kamino-adapter` for Kamino markets and `enclz-save-adapter` for Save markets (each deployed under a separate program ID, Apache-2.0, out-of-tree). Callers invoke lending functionality via `execute_via_adapter` against the appropriate adapter's program ID, which must be registered in the calling group's `GroupAdapterRegistry`.
+
+**Reason for removal:** core program minimization (per-fleet adapter registry change). Lending functionality is preserved with the same semantic contract — deposit and withdraw against whitelisted lending markets, with policy enforcement on the input amount — but now lives in separately-deployed programs governed by the same on-chain registry the owner controls. Removing the instruction from the core shrinks the audit surface and unblocks long-term immutability of the core.
+
+### Requirement: execute_lending_op cpi_data pass-through
+
+The opaque `cpi_data` pattern (where the backend passes pre-encoded CPI bytes through the core) is replaced with the adapter pattern. The adapter is now responsible for building the protocol's CPI from structured inputs, validating those inputs against the adapter's stored `constraints` (e.g., allowed market PDAs), and signing the CPI with the agent_wallet PDA seeds. This restores type safety at the cost of one adapter program per lending protocol family.
+
+### Requirement: execute_lending_op whitelist binding
+
+The owner-approved-adapter check in `execute_via_adapter` replaces the whitelist binding on lending venues. Now the owner must explicitly register the lending adapter (e.g., `enclz-kamino-adapter`) via `add_adapter`, optionally with `constraints: Vec<u8>` encoding the allowed market list. If the owner has not registered the adapter — or if the adapter rejects the call against its `constraints` — lending calls fail at the appropriate level (`AdapterNotApproved` from the core or a typed adapter error).
+
+### Requirement: execute_lending_op deposit and withdraw paths
+
+Both deposit and withdraw paths are preserved in the adapter programs. The deposit/withdraw distinction becomes an argument inside `call_data` parsed by the adapter, rather than a discriminator on the core instruction.

--- a/openspec/changes/2026-05-15-per-fleet-adapter-registry/specs/program-state/spec.md
+++ b/openspec/changes/2026-05-15-per-fleet-adapter-registry/specs/program-state/spec.md
@@ -1,0 +1,29 @@
+## ADDED Requirements
+
+### Requirement: GroupAdapterRegistry PDA
+
+The program SHALL define a `GroupAdapterRegistry` account derived from seeds `["adapter_registry", group_config_pda]` containing `group_config: Pubkey` (back-reference to the owning `GroupConfig`), `bump: u8`, and `entries: Vec<AdapterEntry>` with a hard cap of 32 entries.
+
+Each `AdapterEntry` contains `program_id: Pubkey`, `label: [u8; 32]` (UTF-8, fixed-width, written verbatim with no on-chain encoding validation), `status: u8` (0 = Active, 1 = Paused), `constraints: Vec<u8>` (opaque to the core program; passed verbatim to the adapter on every `execute_via_adapter` call), and `added_at: i64` (unix seconds, as recorded by the runtime clock at insertion time).
+
+The registry is created lazily — `add_adapter` uses `init_if_needed` so the first call materializes the PDA and pays rent; subsequent calls write into the existing account. The registry is not closed when emptied — `remove_adapter` leaves an empty `entries: Vec<>` and the account remains rent-paid.
+
+#### Scenario: PDA derivation matches spec
+- **WHEN** test derives `[b"adapter_registry", group_config_pda.as_ref()]`
+- **THEN** result matches program-side PDA
+
+#### Scenario: AdapterStatus values match documented enum
+- **WHEN** test reads the `AdapterStatus` constants
+- **THEN** `ACTIVE == 0` and `PAUSED == 1`
+
+#### Scenario: INIT_SPACE accommodates header + zero entries
+- **WHEN** test reads `GroupAdapterRegistry::INIT_SPACE`
+- **THEN** the value equals `32 (group_config) + 1 (bump) + 4 (Vec length prefix) = 37` for the empty case
+
+#### Scenario: Max entries enforced
+- **WHEN** an `add_adapter` call would push `entries.len()` past 32
+- **THEN** the instruction fails with `AdapterRegistryFull`
+
+#### Scenario: Back-reference matches owning group
+- **WHEN** test reads `GroupAdapterRegistry.group_config`
+- **THEN** the value equals the `group_config_pda` from the seeds

--- a/openspec/changes/2026-05-15-per-fleet-adapter-registry/specs/swap-execution/spec.md
+++ b/openspec/changes/2026-05-15-per-fleet-adapter-registry/specs/swap-execution/spec.md
@@ -1,0 +1,19 @@
+## REMOVED Requirements
+
+### Requirement: execute_swap instruction signature and account constraints
+
+The `execute_swap` instruction is removed from the core program. Swap functionality moves to a first-party adapter program (`enclz-jupiter-adapter`, deployed under a separate program ID, Apache-2.0, out-of-tree). Callers invoke swap functionality via `execute_via_adapter` against the Jupiter adapter's program ID, which must be registered in the calling group's `GroupAdapterRegistry`.
+
+**Reason for removal:** core program minimization (per-fleet adapter registry change). Swap functionality is preserved with the same semantic contract — Jupiter-v6 quote-driven swap of two SPL tokens, with policy enforcement on the input amount — but now lives in a separately-deployed program governed by the same on-chain registry the owner controls. Removing the instruction from the core shrinks the audit surface and unblocks long-term immutability of the core.
+
+### Requirement: execute_swap protocol fee deduction
+
+Subsumed by `execute_via_adapter`'s policy enforcement plus the adapter's internal fee handling. Removed from the core's responsibility surface.
+
+### Requirement: execute_swap whitelist binding
+
+The owner-approved-adapter check in `execute_via_adapter` replaces the implicit "swap is always allowed if the agent has a swap-capable mint" semantics. Now the owner must explicitly register the Jupiter adapter via `add_adapter` before the agent can execute swaps. If the owner has not registered the adapter, swap calls fail with `AdapterNotApproved`.
+
+### Requirement: execute_swap account constraints
+
+All swap-specific account validation (input/output mints, ATA ownership, Jupiter route data, etc.) moves to the adapter program. The core's `execute_via_adapter` only validates that writable token accounts owned by the agent_wallet PDA remain so after the CPI (custody post-check).

--- a/openspec/changes/2026-05-15-per-fleet-adapter-registry/tasks.md
+++ b/openspec/changes/2026-05-15-per-fleet-adapter-registry/tasks.md
@@ -1,0 +1,76 @@
+## 1. State
+
+- [ ] 1.1 Add `programs/enclz/src/state/adapter_registry.rs` with `GroupAdapterRegistry` and `AdapterEntry` structs, `INIT_SPACE`/`MAX_ENTRIES` constants
+- [ ] 1.2 Register the new module in `programs/enclz/src/state/mod.rs`
+- [ ] 1.3 Add `init_space_adapter_registry_matches_field_layout` and `adapter_registry_round_trip_through_init_space_buffer` unit tests in `programs/enclz/src/lib.rs`
+
+## 2. Errors
+
+- [ ] 2.1 Add `AdapterNotApproved`, `AdapterAlreadyRegistered`, `AdapterRegistryFull` variants to `programs/enclz/src/errors.rs` using the next free 6000-band discriminants
+- [ ] 2.2 Update `error_variants_have_stable_codes` unit test with new discriminants
+
+## 3. add_adapter / remove_adapter instructions
+
+- [ ] 3.1 Add `programs/enclz/src/instructions/add_adapter.rs` — `init_if_needed` for `GroupAdapterRegistry` PDA, owner-signed, append entry, reject duplicates + over-cap
+- [ ] 3.2 Add `programs/enclz/src/instructions/remove_adapter.rs` — owner-signed, remove entry by `program_id`, idempotent on missing
+- [ ] 3.3 Register both in `programs/enclz/src/instructions/mod.rs` and the `#[program]` block in `lib.rs`
+
+## 4. execute_via_adapter instruction
+
+- [ ] 4.1 Add `programs/enclz/src/instructions/execute_via_adapter.rs` — operator-signed, validates `adapter_id` is in `GroupAdapterRegistry.entries` with `status == Active`, applies amount cap + frequency policy checks identical to `execute_transfer`
+- [ ] 4.2 Implement custody post-check: every writable token account in `remaining_accounts` that the CPI touches must be PDA-owned by the agent wallet
+- [ ] 4.3 Forbid Token, ATA, and BPF loader program IDs as CPI targets (defense-in-depth alongside the registry pre-check)
+- [ ] 4.4 Invoke target adapter via `invoke_signed` with the agent_wallet PDA seeds, passing `call_data` and `constraints` from the registry entry
+- [ ] 4.5 Register in `programs/enclz/src/instructions/mod.rs` and the `#[program]` block
+
+## 5. Removed instructions
+
+- [ ] 5.1 Delete `programs/enclz/src/instructions/execute_swap.rs`
+- [ ] 5.2 Delete `programs/enclz/src/instructions/execute_lending_op.rs`
+- [ ] 5.3 Remove their registrations from `instructions/mod.rs` and the `#[program]` block in `lib.rs`
+- [ ] 5.4 Delete corresponding Rust integration test files: `programs/enclz/tests/execute_swap.rs`, `programs/enclz/tests/execute_lending_op.rs`
+- [ ] 5.5 Update `programs/enclz/tests/common/mod.rs` helpers — drop swap/lending fixtures
+
+## 6. Integration tests
+
+- [ ] 6.1 Add `tests/adapter_management.spec.ts` — happy paths + invalid signer + duplicate + over-cap + remove-then-readd + remove-while-not-present (idempotent)
+- [ ] 6.2 Add `tests/execute_via_adapter.spec.ts` — happy path with a mock adapter program, reject if adapter not in registry (`AdapterNotApproved`), reject if non-PDA-owned writable token account, reject if CPI target is a forbidden program ID, daily-cap exhaustion still enforced, frequency cap still enforced
+- [ ] 6.3 Add `programs/mock-adapter` test program crate — a tiny Anchor adapter that echoes back `call_data` for use in execute_via_adapter tests
+- [ ] 6.4 Delete `tests/execute_swap.spec.ts` and `tests/execute_lending_op.spec.ts`
+- [ ] 6.5 Update `tests/smoke.ts` — replace swap/lending paths with one `add_adapter` → `execute_via_adapter` end-to-end pass against the mock adapter
+
+## 7. SDK (`@enclz/sdk`)
+
+- [ ] 7.1 Add `addAdapter`, `removeAdapter`, `executeViaAdapter` helper functions
+- [ ] 7.2 Add `getAdapterRegistry(groupConfigPda)` reader that decodes the PDA
+- [ ] 7.3 Remove `swap`, `deposit`, `withdraw` helpers (downstream callers move to `executeViaAdapter` against the appropriate first-party adapter program ID)
+- [ ] 7.4 Bump SDK major version (breaking change)
+- [ ] 7.5 Regenerate IDL via `anchor build`; re-export the regenerated types
+
+## 8. First-party adapter programs (separate repos)
+
+- [ ] 8.1 Scaffold `enclz/adapter-template` repo — reference Anchor program with the standard adapter entry-point + `constraints` parsing pattern + tests + README
+- [ ] 8.2 Scaffold `enclz/enclz-jupiter-adapter` repo — port the Jupiter-v6 CPI logic from the deleted `execute_swap.rs` plus `constraints` parsing (allowed input/output mints)
+- [ ] 8.3 Scaffold `enclz/enclz-kamino-adapter` repo — port Kamino CPI logic plus `constraints` parsing (allowed market PDAs)
+- [ ] 8.4 Scaffold `enclz/enclz-save-adapter` repo — same shape as Kamino adapter for Save markets
+- [ ] 8.5 Wire each adapter's CI to verify-build, run unit tests, and publish IDL on tag
+- [ ] 8.6 Each adapter freezes upgrade authority after v0.1.0 release + audit
+
+## 9. Devnet release
+
+- [ ] 9.1 Generate fresh `target/deploy/enclz-keypair.json` for v1.0 program ID
+- [ ] 9.2 Update `Anchor.toml` `[programs.*]` sections to the new program ID
+- [ ] 9.3 Update `declare_id!` in `programs/enclz/src/lib.rs`
+- [ ] 9.4 Run `./scripts/verify-devnet-onchain.sh` (or the local equivalent) against the new deployment
+- [ ] 9.5 Deploy the three first-party adapter programs to devnet
+- [ ] 9.6 Update `docs/RELEASE_MANIFEST.devnet.json` with v1.0 program ID + each adapter program ID
+- [ ] 9.7 Bump program version to `v1.0.0` in `programs/enclz/Cargo.toml`
+
+## 10. Build + verify
+
+- [ ] 10.1 `cargo test --package enclz` — all unit tests pass
+- [ ] 10.2 `anchor build` — clean compile, IDL regenerated
+- [ ] 10.3 `cargo clippy --all-targets -- -D warnings` — no warnings
+- [ ] 10.4 LiteSVM runtime tests pass (`cargo test --manifest-path tests/runtime/Cargo.toml`) if applicable to this repo
+- [ ] 10.5 Localnet end-to-end (`scripts/localnet-e2e.py` equivalent) — provisions a group, adds the mock adapter, executes a transfer + an `execute_via_adapter` through it, asserts policy caps
+- [ ] 10.6 `npm run lint` (workspace root) passes


### PR DESCRIPTION
OpenSpec proposal for [#37](https://github.com/enclz/solana/issues/37) — minimal core + owner-managed protocol composability.

Adds `openspec/changes/2026-05-15-per-fleet-adapter-registry/` with the full design:

- `proposal.md` — Why / What Changes / Capabilities (NEW: `adapter-management`, `adapter-execution`; MODIFIED: `program-state`; REMOVED: `swap-execution`, `lending-execution`) / Impact
- `design.md` — Context / Goals / 7 decisions (exact-pin, fail-loud, first-party only, empty default, capability split, opaque constraints, fresh program ID) / Risks
- `tasks.md` — 10-section implementation checklist
- `specs/` — capability deltas for `program-state` (ADDED `GroupAdapterRegistry`), `adapter-management` (ADDED `add_adapter`/`remove_adapter`), `adapter-execution` (ADDED `execute_via_adapter`), `swap-execution` + `lending-execution` (REMOVED)

## Summary of the proposed change

- Core program shrinks to: provisioning, whitelist, `execute_transfer`, `execute_via_adapter`, `add_adapter` / `remove_adapter`
- New `GroupAdapterRegistry` PDA seeded on `["adapter_registry", group_config_pda]` — owner-controlled, hard cap 32 entries, opaque per-adapter `constraints: Vec<u8>` parsed by the adapter
- `execute_via_adapter` validates: adapter is on the owner's approved list (pre-check), policy caps (per-tx, daily, frequency), nonce, custody post-check on writable PDA-owned token accounts, forbidden CPI targets (Token/ATA/loader)
- `execute_swap` and `execute_lending_op` leave the core; functionality moves to first-party adapter programs in separate repos (`enclz-jupiter-adapter`, `enclz-kamino-adapter`, `enclz-save-adapter`) + a public reference `adapter-template`
- v1.0 deploys under a fresh program ID. Existing v0.x groups migrate via a "Migrate Group" wizard in the webapp that calls `add_adapter` against the recommended catalog

## Validation

`openspec validate 2026-05-15-per-fleet-adapter-registry --strict` → clean.

## Reviewing this PR

This PR introduces only the OpenSpec proposal — no source-code changes yet. The expected review surface is the design itself (`proposal.md`, `design.md`, capability `spec.md` files). Implementation lands in subsequent PRs phased per `tasks.md` once the proposal is approved.

## Test plan

- [x] `openspec validate 2026-05-15-per-fleet-adapter-registry --strict` passes
- [ ] Reviewer reads `proposal.md` + `design.md` and confirms alignment with the issue thread
- [ ] Reviewer scans capability `spec.md` deltas for missing scenarios